### PR TITLE
remove GOVERSION env var (as fails deploy on PaaS)

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,5 +6,4 @@ applications:
    instances: 2
    buildpack: go_buildpack
    env:
-     GOVERSION: go1.10
      GOPACKAGENAME: github.com/alext/cf_basic_auth_route_service


### PR DESCRIPTION
When I tried to follow the instructions at: 
https://docs.cloud.service.gov.uk/deploying_services/route_services/#example-route-service-to-add-username-and-password-authentication
`cf push my-basic-auth-service-app --no-start`
was failing with: 
```
 **ERROR** Unable to determine Go version to install: no match found for 1.10.x in [1.12.10 1.12.12 1.13.1 1.13.3]
```
Removing this line fixed the issue for me. _Changing the value e.g. to `go1.12` did not._